### PR TITLE
feat(gentoo): add a gentoo ebuild

### DIFF
--- a/hypremoji-9999.ebuild
+++ b/hypremoji-9999.ebuild
@@ -1,0 +1,47 @@
+EAPI=8
+
+inherit cargo git-r3
+
+DESCRIPTION="A modern emoji picker for Hyprland, written in Rust + GTK4"
+HOMEPAGE="https://github.com/Musagy/hypremoji"
+EGIT_REPO_URI="https://github.com/Musagy/hypremoji"
+
+LICENSE="ISC"
+SLOT="0"
+PROPERTIES="live"
+
+DEPEND="gui-libs/gtk:4"
+RDEPEND="${DEPEND}
+	media-fonts/noto-emoji
+	gui-apps/wl-clipboard
+	gui-wm/hyprland"
+
+BDEPEND="dev-lang/rust virtual/pkgconfig"
+
+src_unpack() {
+	git-r3_src_unpack
+	cargo_live_src_unpack
+}
+
+src_compile() {
+	cargo_src_compile
+}
+
+src_install() {
+	dobin target/*/hypremoji || die
+
+	insinto /usr/share/hypremoji/assets
+	doins -r assets/*
+
+	insinto /usr/share/hypremoji
+	doins config/hypremoji.conf
+	doins config/config.json
+
+	dodoc LICENSE
+}
+
+pkg_postinst() {
+    if [[ ${D} == "/" ]]; then
+        source "${FILESDIR}/hypremoji.install"
+    fi
+}

--- a/hypremoji.install
+++ b/hypremoji.install
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [[ -n "$EBUILD_PHASE" ]]; then
+    RUN_MODE="gentoo"
+else
+    RUN_MODE="arch"
+fi
+
 post_install() {
     echo "==> Setting up hypremoji..."
 
@@ -286,3 +292,11 @@ EOF
     echo "    Note: New styles added to the end of your style.css"
     echo "    Your custom theme remains intact!"
 }
+
+case "$RUN_MODE" in
+    gentoo)
+        post_install
+        ;;
+    arch)
+        ;;
+esac


### PR DESCRIPTION
The point of this was i really needed a emoji manager for Hyprland however i was on gentoo now instead of doing it manually i just made this now other gentoo nerds can use this with Portage!

Now it will require that someone makes a overlay or adds it to hypr-overlay or someone can instruct the user to make a local repo which is what i did

Mainly recommended to put it in gui-apps/hypremoji! 